### PR TITLE
CTCTRADERS-344 | Adding mock ref data connector to get list of countries

### DIFF
--- a/test/controllers/VehicleRegistrationCountryControllerSpec.scala
+++ b/test/controllers/VehicleRegistrationCountryControllerSpec.scala
@@ -137,12 +137,14 @@ class VehicleRegistrationCountryControllerSpec extends SpecBase with MockitoSuga
       val mockSessionRepository = mock[SessionRepository]
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      when(mockReferenceDataConnector.getCountryList()(any(), any())).thenReturn(Future.successful(countries))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[ReferenceDataConnector].toInstance(mockReferenceDataConnector)
           )
           .build()
 


### PR DESCRIPTION
To fix issue with failing test in Jenkins - https://build.tax.service.gov.uk/job/Common%20Transit%20Convention%20Traders/job/declare-transit-movement-unloading-frontend/lastCompletedBuild/testReport/controllers/VehicleRegistrationCountryControllerSpec/VehicleRegistrationCountry_Controller_must_redirect_to_the_next_page_when_valid_data_is_submitted/