### PR TITLE
Ctctraders 345 - seals on unloading summary

### DIFF
--- a/app/controllers/UnloadingSummaryController.scala
+++ b/app/controllers/UnloadingSummaryController.scala
@@ -60,6 +60,7 @@ class UnloadingSummaryController @Inject()(
             "mrn"           -> mrn,
             "redirectUrl"   -> redirectUrl.url,
             "addCommentUrl" -> addCommentUrl.url,
+            "addSealsUrl"   -> "",
             "sealsSection"  -> Json.toJson(sealsSection),
             "sections"      -> Json.toJson(sections)
           )

--- a/app/derivable/Derivable.scala
+++ b/app/derivable/Derivable.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package derivable
+
+import queries.Gettable
+
+trait Derivable[A, B] extends Gettable[A] {
+
+  val derive: A => B
+
+}

--- a/app/derivable/DeriveNumberOfSeals.scala
+++ b/app/derivable/DeriveNumberOfSeals.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package derivable
+
+import models.Index
+import play.api.libs.json.JsPath
+
+final case class DeriveNumberOfSeals(eventIndex: Index) extends Derivable[List[Seal], Int] {
+
+  override val derive: List[Seal] => Int = _.size
+
+  override def path: JsPath = JsPath \ SectionConstants.events \ eventIndex.position \ SectionConstants.seals
+}

--- a/app/viewModels/UnloadingSummaryViewModel.scala
+++ b/app/viewModels/UnloadingSummaryViewModel.scala
@@ -31,14 +31,14 @@ object UnloadingSummaryViewModel {
 
     implicit val unloadingSummaryRow: UnloadingSummaryRow = new UnloadingSummaryRow(userAnswers)
 
-    UnloadingSummaryViewModel(SealsSection(userAnswers) ++ TransportSection(userAnswers) ++ ItemsSection(userAnswers))
+    UnloadingSummaryViewModel(TransportSection(userAnswers) ++ ItemsSection(userAnswers))
   }
 
 }
 
 object SealsSection {
 
-  def apply(userAnswers: UserAnswers)(implicit unloadingPermission: UnloadingPermission, unloadingSummaryRow: UnloadingSummaryRow): Seq[Section] =
+  def apply(userAnswers: UserAnswers)(implicit unloadingPermission: UnloadingPermission, unloadingSummaryRow: UnloadingSummaryRow): Option[Seq[Section]] =
     unloadingPermission.seals match {
       case Some(seals) =>
         val rows: Seq[Row] = seals.SealId.zipWithIndex.map(
@@ -47,9 +47,10 @@ object SealsSection {
             SummaryRow.rowWithIndex(Index(unloadingPermissionValue._2))(sealAnswer)(unloadingPermissionValue._1)(unloadingSummaryRow.seals)
           }
         )
-        Seq(Section(msg"changeSeal.title", rows))
 
-      case None => Seq.empty
+        Some(Seq(Section(msg"changeSeal.title", rows)))
+
+      case None => None
     }
 }
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -172,7 +172,8 @@ newSealNumber.error.length = Seal number or mark must be 100 characters or less
 
 unloadingSummary.title = Check what you found against the transit declaration
 unloadingSummary.heading = Check what you found against the transit declaration
-unloadingSummary.link.text = Add comment
+unloadingSummary.addSeal.link.text = Add a new seal number
+unloadingSummary.addComment.link.text = Add comment
 
 vehicleUsed.title = Vehicle used
 changeVehicle.reference.label = Name, registration or reference

--- a/conf/views/unloadingSummary.njk
+++ b/conf/views/unloadingSummary.njk
@@ -23,13 +23,21 @@
           {{ messages("unloadingSummary.heading") }}
         </h1>
 
+        {% if sealsSection %}
+          {% for section in sealsSection %}
+            {{ sectionMacro(section.sectionTitle, section.rows) }}
+          {% endfor %}
+        {% else %}
+            <h2 class="govuk-heading-m">Seals</h2>
+            <p class="govuk-body">There are no seals.</p>
+        {% endif %}
+        <p class ="govuk-body"><a id="value" href="{{ addSealUrl }}" class="govuk-link"> {{ messages("unloadingSummary.addSeal.link.text") }}</a></p>
+
         {% for section in sections %}
           {{ sectionMacro(section.sectionTitle, section.rows) }}
         {% endfor %}
 
-        <p class ="govuk-body">
-                    <a id="value" href="{{ addCommentUrl }}" class="govuk-link"> {{ messages("unloadingSummary.link.text") }} </a>
-                  </p>
+        <p class ="govuk-body"><a id="value" href="{{ addCommentUrl }}" class="govuk-link"> {{ messages("unloadingSummary.addComment.link.text") }}</a></p>
 
         {{ govukButton({
           text: messages("site.continue"),

--- a/test/viewModels/SealsSectionSpec.scala
+++ b/test/viewModels/SealsSectionSpec.scala
@@ -63,7 +63,7 @@ class SealsSectionSpec extends SpecBase {
 
       val withSeals = unloadingPermission.copy(seals = Some(Seals(1, Seq("seal 1", "seal 2"))))
 
-      val data: Seq[Section] = SealsSection(emptyUserAnswers)(withSeals, new UnloadingSummaryRow(emptyUserAnswers))
+      val data: Seq[Section] = SealsSection(emptyUserAnswers)(withSeals, new UnloadingSummaryRow(emptyUserAnswers)).head
       data.head.rows(0).value.content mustBe Literal("seal 1")
       data.head.rows(1).value.content mustBe Literal("seal 2")
     }
@@ -80,7 +80,7 @@ class SealsSectionSpec extends SpecBase {
         .success
         .value
 
-      val data: Seq[Section] = SealsSection(updatedUserAnswers)(withSeals, new UnloadingSummaryRow(updatedUserAnswers))
+      val data: Seq[Section] = SealsSection(updatedUserAnswers)(withSeals, new UnloadingSummaryRow(updatedUserAnswers)).head
       data.head.rows(0).value.content mustBe Literal("new seal value 1")
       data.head.rows(1).value.content mustBe Literal("new seal value 2")
     }
@@ -89,8 +89,8 @@ class SealsSectionSpec extends SpecBase {
 
       val noSeals = unloadingPermission.copy(seals = None)
 
-      val data: Seq[Section] = SealsSection(emptyUserAnswers)(noSeals, new UnloadingSummaryRow(emptyUserAnswers))
-      data mustBe Nil
+      val data: Option[Seq[Section]] = SealsSection(emptyUserAnswers)(noSeals, new UnloadingSummaryRow(emptyUserAnswers))
+      data mustBe None
     }
 
   }

--- a/test/viewModels/UnloadingSummaryViewModelSpec.scala
+++ b/test/viewModels/UnloadingSummaryViewModelSpec.scala
@@ -56,43 +56,6 @@ class UnloadingSummaryViewModelSpec extends FreeSpec with MustMatchers with Spec
 
   "UnloadingSummaryViewModel" - {
 
-    "seals section should" - {
-      "display no seals" in {
-
-        val data = UnloadingSummaryViewModel(emptyUserAnswers)(unloadingPermission)
-
-        data.sections.length mustBe 1
-      }
-
-      "display seals" in {
-
-        val withSeals = unloadingPermission.copy(seals = Some(Seals(1, Seq("seal 1", "seal 2"))))
-
-        val data = UnloadingSummaryViewModel(emptyUserAnswers)(withSeals)
-
-        data.sections.length mustBe 2
-        data.sections.head.sectionTitle mustBe defined
-        data.sections.head.rows.length mustBe 2
-      }
-
-      "display seals with transport details" in {
-
-        val withSeals = unloadingPermission.copy(seals = Some(Seals(1, Seq("seal 1", "seal 2"))),
-                                                 transportCountry  = Some("registration"),
-                                                 transportIdentity = Some("registration"))
-
-        val data = UnloadingSummaryViewModel(emptyUserAnswers)(withSeals)
-
-        data.sections.length mustBe 3
-        data.sections(0).sectionTitle mustBe defined
-        data.sections(0).rows.length mustBe 2
-        data.sections(1).sectionTitle mustBe defined
-        data.sections(1).rows.length mustBe 2
-        data.sections(2).sectionTitle mustBe defined
-        data.sections(2).rows.length mustBe 2
-      }
-    }
-
     "vehicle section should" - {
 
       "display transportIdentity" in {


### PR DESCRIPTION
Update to the seals display on unloading summary, broken out the seals and updated the template to allow a different display if present or not.