### PR TITLE
CTCTRADERS-1102:  Fix issue submitting IE044 with comments

### DIFF
--- a/app/models/messages/Remarks.scala
+++ b/app/models/messages/Remarks.scala
@@ -44,24 +44,38 @@ object Remarks {
   }
 }
 
-case class RemarksConform(unloadingDate: LocalDate) extends Remarks {
+case class RemarksConform(unloadingDate: LocalDate, unloadingRemark: Option[String]) extends Remarks {
   val conform = "1"
 }
 
 object RemarksConform {
   implicit val writes: XMLWrites[RemarksConform] = {
 
-    XMLWrites(remarks => <UNLREMREM>
-      <ConREM65>{remarks.conform}</ConREM65>
-      <UnlComREM66>{remarks.unloadingCompleted}</UnlComREM66>
-      <UnlDatREM67>{Format.dateFormatted(remarks.unloadingDate)}</UnlDatREM67>
-    </UNLREMREM>)
+    XMLWrites(remarks => {
+
+      val unloadingRemarks = remarks.unloadingRemark.map {
+        remarks =>
+          <UnlRemREM53>{remarks}</UnlRemREM53>
+            <UnlRemREM53LNG>{LanguageCodeEnglish.code}</UnlRemREM53LNG>
+      }
+
+      <UNLREMREM>
+        {unloadingRemarks.getOrElse(NodeSeq.Empty)}
+        <ConREM65>{remarks.conform}</ConREM65>
+        <UnlComREM66>{remarks.unloadingCompleted}</UnlComREM66>
+        <UnlDatREM67>{Format.dateFormatted(remarks.unloadingDate)}</UnlDatREM67>
+      </UNLREMREM>
+    })
   }
 
-  implicit val xmlReader: XmlReader[RemarksConform] = (__ \ "UnlDatREM67").read[LocalDate] map apply
+  implicit val xmlReader: XmlReader[RemarksConform] =
+    (
+      (__ \ "UnlDatREM67").read[LocalDate],
+      (__ \ "UnlRemREM53").read[String].optional
+    ) mapN apply
 }
 
-case class RemarksConformWithSeals(unloadingDate: LocalDate) extends Remarks {
+case class RemarksConformWithSeals(unloadingDate: LocalDate, unloadingRemark: Option[String]) extends Remarks {
   val conform      = "1"
   val stateOfSeals = "1"
 }
@@ -69,20 +83,35 @@ case class RemarksConformWithSeals(unloadingDate: LocalDate) extends Remarks {
 object RemarksConformWithSeals {
   implicit val writes: XMLWrites[RemarksConformWithSeals] = {
 
-    XMLWrites(remarks => <UNLREMREM>
-      <StaOfTheSeaOKREM19>{remarks.stateOfSeals}</StaOfTheSeaOKREM19>
-      <ConREM65>{remarks.conform}</ConREM65>
-      <UnlComREM66>{remarks.unloadingCompleted}</UnlComREM66>
-      <UnlDatREM67>{Format.dateFormatted(remarks.unloadingDate)}</UnlDatREM67>
-    </UNLREMREM>)
+    XMLWrites(remarks => {
+
+      val unloadingRemarks = remarks.unloadingRemark.map {
+        remarks =>
+          <UnlRemREM53>{remarks}</UnlRemREM53>
+            <UnlRemREM53LNG>{LanguageCodeEnglish.code}</UnlRemREM53LNG>
+      }
+
+      <UNLREMREM>
+        <StaOfTheSeaOKREM19>{remarks.stateOfSeals}</StaOfTheSeaOKREM19>
+        {unloadingRemarks.getOrElse(NodeSeq.Empty)}
+        <ConREM65>{remarks.conform}</ConREM65>
+        <UnlComREM66>{remarks.unloadingCompleted}</UnlComREM66>
+        <UnlDatREM67>{Format.dateFormatted(remarks.unloadingDate)}</UnlDatREM67>
+      </UNLREMREM>
+
+    })
   }
 
-  implicit val xmlReader: XmlReader[RemarksConformWithSeals] = (__ \ "UnlDatREM67").read[LocalDate] map apply
+  implicit val xmlReader: XmlReader[RemarksConformWithSeals] =
+    (
+      (__ \ "UnlDatREM67").read[LocalDate],
+      (__ \ "UnlRemREM53").read[String].optional
+    ) mapN apply
 }
 
 case class RemarksNonConform(
   stateOfSeals: Option[Int],
-  unloadingRemark: Option[String], //TODO: Can we have non conform with no results of control and unloading remarks
+  unloadingRemark: Option[String],
   unloadingDate: LocalDate
 ) extends Remarks {
   val conform = "0"
@@ -105,12 +134,12 @@ object RemarksNonConform {
       val unloadingRemarks = remarks.unloadingRemark.map {
         remarks =>
           <UnlRemREM53>{remarks}</UnlRemREM53>
+          <UnlRemREM53LNG>{LanguageCodeEnglish.code}</UnlRemREM53LNG>
       }
 
       <UNLREMREM>
         {stateOfSeals.getOrElse(NodeSeq.Empty)}
         {unloadingRemarks.getOrElse(NodeSeq.Empty)}
-        <UnlRemREM53LNG>{LanguageCodeEnglish.code}</UnlRemREM53LNG>
         <ConREM65>{remarks.conform}</ConREM65>
         <UnlComREM66>{remarks.unloadingCompleted}</UnlComREM66>
         <UnlDatREM67>{Format.dateFormatted(remarks.unloadingDate)}</UnlDatREM67>

--- a/app/services/RemarksService.scala
+++ b/app/services/RemarksService.scala
@@ -60,30 +60,12 @@ class RemarksServiceImpl @Inject()(resultOfControlService: ResultOfControlServic
             unloadingDate   = unloadingDate
           ))
       } else {
-        userAnswers.get(ChangesToReportPage) match {
-          case Some(unloadingRemarks) =>
-            Future.successful(
-              RemarksNonConform(
-                stateOfSeals    = Some(1),
-                unloadingRemark = Some(unloadingRemarks),
-                unloadingDate   = unloadingDate
-              )
-            )
-          case None => {
-
-            if (resultsOfControl.isEmpty) {
-              Future.successful(RemarksConformWithSeals(unloadingDate))
-            } else {
-              Future.successful(
-                RemarksNonConform(
-                  stateOfSeals    = Some(1),
-                  unloadingRemark = None,
-                  unloadingDate   = unloadingDate
-                ))
-            }
-
-          }
-        }
+        Future.successful(
+          RemarksConformWithSeals(
+            unloadingRemark = userAnswers.get(ChangesToReportPage),
+            unloadingDate   = unloadingDate
+          )
+        )
       }
     }
 
@@ -91,7 +73,7 @@ class RemarksServiceImpl @Inject()(resultOfControlService: ResultOfControlServic
 
   private def unloadingPermissionDoesNotContainSeals(
     userAnswers: UserAnswers)(implicit unloadingDate: LocalDate, resultsOfControl: Seq[ResultsOfControl]): PartialFunction[Option[Seals], Response] = {
-    case None => {
+    case None =>
       userAnswers.get(DeriveNumberOfSeals) match {
         case Some(_) =>
           Future.successful(
@@ -101,31 +83,14 @@ class RemarksServiceImpl @Inject()(resultOfControlService: ResultOfControlServic
               unloadingDate   = unloadingDate
             )
           )
-        case None => {
-          userAnswers.get(ChangesToReportPage) match {
-            case Some(unloadingRemarks) =>
-              Future.successful(
-                RemarksNonConform(
-                  stateOfSeals    = None,
-                  unloadingRemark = Some(unloadingRemarks),
-                  unloadingDate   = unloadingDate
-                )
-              )
-            case None =>
-              if (resultsOfControl.isEmpty) {
-                Future.successful(RemarksConform(unloadingDate))
-              } else {
-                Future.successful(
-                  RemarksNonConform(
-                    stateOfSeals    = None,
-                    unloadingRemark = None,
-                    unloadingDate   = unloadingDate
-                  ))
-              }
-          }
-        }
+        case None =>
+          Future.successful(
+            RemarksConform(
+              unloadingRemark = userAnswers.get(ChangesToReportPage),
+              unloadingDate   = unloadingDate
+            )
+          )
       }
-    }
   }
 }
 

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -219,16 +219,18 @@ trait ModelGenerators {
   implicit lazy val arbitraryRemarksConform: Arbitrary[RemarksConform] = {
     Arbitrary {
       for {
-        date <- arbitrary[LocalDate]
-      } yield RemarksConform(date)
+        date            <- arbitrary[LocalDate]
+        unloadingRemark <- Gen.option(stringsWithMaxLength(RemarksNonConform.unloadingRemarkLength))
+      } yield RemarksConform(date, unloadingRemark)
     }
   }
 
   implicit lazy val arbitraryRemarksConformWithSeals: Arbitrary[RemarksConformWithSeals] = {
     Arbitrary {
       for {
-        date <- arbitrary[LocalDate]
-      } yield RemarksConformWithSeals(date)
+        date            <- arbitrary[LocalDate]
+        unloadingRemark <- Gen.option(stringsWithMaxLength(RemarksNonConform.unloadingRemarkLength))
+      } yield RemarksConformWithSeals(date, unloadingRemark)
     }
   }
 

--- a/test/models/messages/RemarksSpec.scala
+++ b/test/models/messages/RemarksSpec.scala
@@ -37,8 +37,15 @@ class RemarksSpec extends FreeSpec with MustMatchers with Generators with ModelG
 
         forAll(arbitrary[RemarksConform]) {
           remarksConform =>
+            val unloadingRemarks: Option[NodeSeq] = remarksConform.unloadingRemark.map {
+              remarks =>
+                <UnlRemREM53>{remarks}</UnlRemREM53> ++
+                  <UnlRemREM53LNG>EN</UnlRemREM53LNG>
+            }
+
             val xml: Node =
               <UNLREMREM>
+                {unloadingRemarks.getOrElse(NodeSeq.Empty)}
                 <ConREM65>1</ConREM65>
                 <UnlComREM66>1</UnlComREM66>
                 <UnlDatREM67>{Format.dateFormatted(remarksConform.unloadingDate)}</UnlDatREM67>
@@ -61,9 +68,16 @@ class RemarksSpec extends FreeSpec with MustMatchers with Generators with ModelG
 
         forAll(arbitrary[RemarksConformWithSeals]) {
           remarksConformWithSeals =>
+            val unloadingRemarks: Option[NodeSeq] = remarksConformWithSeals.unloadingRemark.map {
+              remarks =>
+                <UnlRemREM53>{remarks}</UnlRemREM53> ++
+                  <UnlRemREM53LNG>EN</UnlRemREM53LNG>
+            }
+
             val xml: Node =
               <UNLREMREM>
                 <StaOfTheSeaOKREM19>1</StaOfTheSeaOKREM19>
+                {unloadingRemarks.getOrElse(NodeSeq.Empty)}
                 <ConREM65>1</ConREM65>
                 <UnlComREM66>1</UnlComREM66>
                 <UnlDatREM67>{Format.dateFormatted(remarksConformWithSeals.unloadingDate)}</UnlDatREM67>
@@ -90,16 +104,16 @@ class RemarksSpec extends FreeSpec with MustMatchers with Generators with ModelG
                 <StaOfTheSeaOKREM19>{int}</StaOfTheSeaOKREM19>
             }
 
-            val unloadingRemarks: Option[Elem] = remarksNonConform.unloadingRemark.map {
+            val unloadingRemarks = remarksNonConform.unloadingRemark.map {
               remarks =>
-                <UnlRemREM53>{remarks}</UnlRemREM53>
+                <UnlRemREM53>{remarks}</UnlRemREM53> ++
+                  <UnlRemREM53LNG>EN</UnlRemREM53LNG>
             }
 
             val xml: NodeSeq =
               <UNLREMREM>
                 {stateOfSeals.getOrElse(NodeSeq.Empty)}
                 {unloadingRemarks.getOrElse(NodeSeq.Empty)}
-                <UnlRemREM53LNG>EN</UnlRemREM53LNG>
                 <ConREM65>0</ConREM65>
                 <UnlComREM66>1</UnlComREM66>
                 <UnlDatREM67>{Format.dateFormatted(remarksNonConform.unloadingDate)}</UnlDatREM67>

--- a/test/services/UnloadingRemarksRequestServiceSpec.scala
+++ b/test/services/UnloadingRemarksRequestServiceSpec.scala
@@ -22,6 +22,7 @@ import generators.MessagesModelGenerators
 import models.messages._
 import models.{Index, Seals, UnloadingPermission}
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.{NewSealNumberPage, VehicleNameRegistrationReferencePage}
 
@@ -37,9 +38,12 @@ class UnloadingRemarksRequestServiceSpec extends SpecBase with AppWithDefaultMoc
 
         val unloadingRemarksRequestService = app.injector.instanceOf[UnloadingRemarksRequestService]
 
-        forAll(arbitrary[UnloadingPermission], arbitrary[Meta], arbitrary[LocalDateTime]) {
-          (unloadingPermission, meta, localDateTime) =>
-            val unloadingRemarks = RemarksConform(localDateTime.toLocalDate)
+        forAll(arbitrary[UnloadingPermission],
+               arbitrary[Meta],
+               arbitrary[LocalDateTime],
+               Gen.option(stringsWithMaxLength(RemarksNonConform.unloadingRemarkLength))) {
+          (unloadingPermission, meta, localDateTime, unloadingRemark) =>
+            val unloadingRemarks = RemarksConform(localDateTime.toLocalDate, unloadingRemark)
 
             unloadingRemarksRequestService.build(meta, unloadingRemarks, unloadingPermission, emptyUserAnswers) mustBe
               UnloadingRemarksRequest(
@@ -58,9 +62,12 @@ class UnloadingRemarksRequestServiceSpec extends SpecBase with AppWithDefaultMoc
 
         val unloadingRemarksRequestService = app.injector.instanceOf[UnloadingRemarksRequestService]
 
-        forAll(arbitrary[UnloadingPermission], arbitrary[Meta], arbitrary[LocalDateTime]) {
-          (unloadingPermission, meta, localDateTime) =>
-            val unloadingRemarks = RemarksConformWithSeals(localDateTime.toLocalDate)
+        forAll(arbitrary[UnloadingPermission],
+               arbitrary[Meta],
+               arbitrary[LocalDateTime],
+               Gen.option(stringsWithMaxLength(RemarksNonConform.unloadingRemarkLength))) {
+          (unloadingPermission, meta, localDateTime, unloadingRemark) =>
+            val unloadingRemarks = RemarksConformWithSeals(localDateTime.toLocalDate, unloadingRemark)
 
             unloadingRemarksRequestService.build(meta, unloadingRemarks, unloadingPermission, emptyUserAnswers) mustBe
               UnloadingRemarksRequest(


### PR DESCRIPTION
Update to not set the IE044 to _conform_ if unloading comments have been made (previously this was non conform which is incorrect)